### PR TITLE
Joindiaspora sunset messaging

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -110,3 +110,5 @@
 
 // OpenID Connect (API)
 @import 'openid_connect_error_page';
+
+@import 'sunset';

--- a/app/assets/stylesheets/sunset.scss
+++ b/app/assets/stylesheets/sunset.scss
@@ -1,0 +1,18 @@
+#sunset-message-container {
+  font-size: 1.2em;
+
+  h3 {
+    border-bottom: 1px dashed #ddd;
+    font-weight: bold;
+    margin: 0 0 15px;
+    padding-bottom: 15px;
+  }
+
+  .row {
+    margin-bottom: 2em;
+  }
+
+  .framed-content {
+    padding: 15px;
+  }
+}

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -7,7 +7,7 @@ class RedirectsController < ApplicationController
     if user_signed_in?
       redirect_to edit_user_path
     else
-      redirect_to root_path
+      redirect_to new_user_session_path
     end
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,8 @@
   %body{class: "page-#{controller_name} action-#{action_name}"}
     = yield :before_content
 
+    = render partial: "shared/sunset_message"
+
     %noscript
       .noscript
         %h3= t("error_messages.need_javascript")

--- a/app/views/shared/_sunset_message.erb
+++ b/app/views/shared/_sunset_message.erb
@@ -1,0 +1,35 @@
+<div id="sunset-message-container" class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="framed-content">
+        <h3>You are here to learn about the diaspora* project?</h3>
+        <p>
+          <strong>This is not the official project website.</strong> To learn what diaspora* is, how to sign up to an
+          existing pod, or how to set up your own pod, please visit
+          <a href="https://diasporafoundation.org" target="_blank">the official project website</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <div class="framed-content">
+        <h3>JoinDiaspora has reached its End of Life.</h3>
+        <p>
+          <strong>Please see <a href="https://pod.diaspora.software/posts/4984491" target="_blank">the official
+          announcement post for details on JoinDiaspora's future</a></strong>, and for how to get in touch with the team.
+        </p>
+        <p>
+          As such, all features are disabled, including the ability to post new content. However, you still can:
+        </p>
+        <ul>
+          <li>Export your data, and initiate the account migration as soon it's done.</li>
+          <li>Send and receive private messages.</li>
+          <li>Delete your account.</li>
+          <li>Manage your profile and account details.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_edit.haml
+++ b/app/views/users/_edit.haml
@@ -8,10 +8,6 @@
 .row
   .col-md-12
     .row
-      .col-md-12
-        TODO: write some text about joindiaspora
-
-    .row
       .col-md-6.account-data
         %h3= t(".export_data")
         %h4= t("profile")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,7 @@ Rails.application.routes.draw do
   end
 
   # Startpage
-  root :to => 'home#show'
+  root :to => 'redirects#redirect'
   get "podmin" => redirect("/")
 
   get "manifest.json", to: "manifest#show"


### PR DESCRIPTION
Not super pretty, but functional.

- Application layout when signed in: [Screenshot](https://user-images.githubusercontent.com/344777/156058036-be82b0e1-6803-4c46-84ce-5f81bdcd2746.png)
- Sign in view: [Screenshot](https://user-images.githubusercontent.com/344777/156058114-9c3e9812-d10b-46f9-a30a-62160044027e.png)

@SuperTux88, is there a reason why you use explicit routes to `"redirects#redirect"` instead of throwing 404s and handling that 404 with a redirect?

